### PR TITLE
utilizing getConnection and getMetaplex utils

### DIFF
--- a/library/nft/transfer.ts
+++ b/library/nft/transfer.ts
@@ -1,11 +1,11 @@
-
-import { PublicKey, TransactionInstruction, Connection, Keypair, Transaction } from '@solana/web3.js';
+import {Connection, Keypair, PublicKey, Transaction, TransactionInstruction} from '@solana/web3.js';
 import {
+    createTransferInstruction,
     getAssociatedTokenAddress,
-    getOrCreateAssociatedTokenAccount,
-    createTransferInstruction
+    getOrCreateAssociatedTokenAccount
 } from '@solana/spl-token';
-import { adminWallet, connection } from '../../pages/api/_constants';
+import {adminWallet} from '../../pages/api/_constants';
+import {getConnection} from "../../utils/get-connection";
 
 /** Parameters for {@link sendToken} **/
 export interface SendTokenParams {
@@ -64,6 +64,9 @@ export const getTokenTransferInstructions = async ({
 export const transferAdminNftTransaction = async (
     mint: PublicKey, to: PublicKey
     ): Promise<Transaction> => {
+
+    const connection = getConnection()
+
     // associated token account for the NFT & admin wallet
     const ata = await getAssociatedTokenAddress(mint, adminWallet.publicKey);
 

--- a/pages/api/_constants.ts
+++ b/pages/api/_constants.ts
@@ -4,14 +4,7 @@ import {keypairIdentity} from "@metaplex-foundation/js";
 import {Keypair} from "@solana/web3.js";
 import * as bs58 from "bs58";
 import {AuthorizationFailureResponse} from "./_responses";
-import {getConnection} from "../../utils/get-connection";
 import {getMetaplex} from "../../utils/get-metaplex";
-
-// init'd objects to be used in API (and not Pages, which should use contexts)
-// assumes that APIs using the objects will use default networks (production -> mainnet, otherwise devnet)
-// if an API needs to use a specific network, it should call the getters itself
-export const connection = getConnection();
-export const metaplex = getMetaplex();
 
 export const adminWallet = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY!));
 export const signable_metaplex = getMetaplex().use(keypairIdentity(adminWallet));

--- a/pages/api/nft/owned.ts
+++ b/pages/api/nft/owned.ts
@@ -2,7 +2,6 @@
 import type {NextApiResponse} from 'next';
 import {Nft} from "@metaplex-foundation/js";
 import {PublicKey} from "@solana/web3.js";
-import {metaplex} from "../_constants";
 import {corsMiddleware} from "../../../utils/middleware";
 import {GetOwnedNftsRequest} from "../_requests";
 import {MissingArgsResponse, OwnedNftsResponse} from "../_responses";
@@ -24,9 +23,7 @@ export default async function handler(
     const network = req.query.network
 
     // use specific network, if provided by the request. otherwise use the default
-    const mx = network
-        ? getMetaplex(getConnection(network))
-        : metaplex;
+    const mx = getMetaplex(getConnection(network));
 
     await corsMiddleware(["GET"], req, res)
 

--- a/pages/api/nft/print/[masterEdition].ts
+++ b/pages/api/nft/print/[masterEdition].ts
@@ -2,12 +2,14 @@
 import type {NextApiResponse} from 'next';
 import {Nft} from "@metaplex-foundation/js";
 import {PublicKey, sendAndConfirmTransaction} from "@solana/web3.js";
-import {adminWallet, AUTHORIZATION_FAILED, connection, metaplex, signable_metaplex} from "../../_constants";
+import {adminWallet, AUTHORIZATION_FAILED, signable_metaplex} from "../../_constants";
 import {basicAuthMiddleware, corsMiddleware} from '../../../../utils/middleware';
 import {transferAdminNftTransaction} from "../../../../library/nft/transfer";
 import {GetPrintNftRequest, PostPrintNftRequest} from "../../_requests";
 import {AuthorizationFailureResponse, PrintNftResponse} from "../../_responses";
 import {StatusCodes} from "http-status-codes";
+import {getConnection} from "../../../../utils/get-connection";
+import {getMetaplex} from "../../../../utils/get-metaplex";
 
 // example POST:
 // api/nft/print/2eqiaDuGJNrBniLR2D9YADJfsC9FzyPnfo159L6LKR6G
@@ -20,6 +22,9 @@ export default async function handler(
     const masterEdition = req.query.masterEdition
     const to = req.query.to
 
+    const connection = getConnection()
+    const mx = getMetaplex()
+
     await corsMiddleware(["GET", "POST"], req, res)
 
     switch (req.method) {
@@ -27,7 +32,7 @@ export default async function handler(
         case 'GET':
             // @TODO: this route should actually return all print editions
             // we may need to crawl the chain, or use `findAllByCreator(adminWallet)`
-            const nft: Nft = await metaplex.nfts()
+            const nft: Nft = await mx.nfts()
                 .findByMint(new PublicKey(masterEdition));
 
             const responseBody: PrintNftResponse = {

--- a/pages/api/nft/transfer.ts
+++ b/pages/api/nft/transfer.ts
@@ -2,12 +2,14 @@
 import type {NextApiResponse} from 'next';
 import {Nft} from "@metaplex-foundation/js";
 import {PublicKey, sendAndConfirmTransaction, Transaction} from "@solana/web3.js";
-import {adminWallet, AUTHORIZATION_FAILED, connection, metaplex} from "../_constants";
+import {adminWallet, AUTHORIZATION_FAILED} from "../_constants";
 import {transferAdminNftTransaction} from '../../../library/nft/transfer';
 import {basicAuthMiddleware, corsMiddleware} from '../../../utils/middleware';
 import {PostTransferRequest} from "../_requests";
 import {AuthorizationFailureResponse, SuccessResponse} from "../_responses";
 import {StatusCodes} from "http-status-codes";
+import {getConnection} from "../../../utils/get-connection";
+import {getMetaplex} from "../../../utils/get-metaplex";
 
 
 // example POST:
@@ -21,6 +23,9 @@ export default async function handler(
     const token = req.query.token
     const to = req.query.to
 
+    const connection = getConnection()
+    const mx = getMetaplex()
+
     await corsMiddleware(["POST"], req, res)
 
     switch (req.method) {
@@ -33,7 +38,7 @@ export default async function handler(
             }
 
             // obtain NFT to transfer
-            const nft: Nft = await metaplex.nfts().findByMint(new PublicKey(token));
+            const nft: Nft = await mx.nfts().findByMint(new PublicKey(token));
 
             // construct tx for transferring it to the destination
             const tx: Transaction = await transferAdminNftTransaction(

--- a/utils/get-connection.ts
+++ b/utils/get-connection.ts
@@ -12,7 +12,7 @@ export const getConnection = (network?: string | WalletAdapterNetwork | undefine
         return new Connection(clusterApiUrl(nw))
     }
 
-    // return mainnet connection for production otherwise default to devnet
+    // by default, return mainnet for production and devnet otherwise
     return process.env.VERCEL_ENV === 'production'
         ? new Connection(clusterApiUrl(WalletAdapterNetwork.Mainnet))
         : new Connection(clusterApiUrl(WalletAdapterNetwork.Devnet))


### PR DESCRIPTION
This PR removes the `connection` and `metaplex` exports from `_constants` in favor of using the `getConnection()` and `getMetaplex()` utility functions. In addition to ensuring better consistency, this also solves an issue experienced by utilizing the exported values: 

Whenever the original `connection` or `metaplex` was imported into an API file, the `adminWallet` would be processed by fetching the `SOLANA_PRIVATE_KEY` environment variable. If this was not already set by the user locally, the `bs58.decode()` method would fail due to `undefined` being passed in. This prevented API access to endpoints that don't even utilize the `adminWallet` keypair. Now that we're moving towards being open source, we need to ensure that the `adminWallet` is only utilized/included in the specific instances where it's needed so as to not block others. 