### PR TITLE
Bug fix for max supply

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -128,7 +128,7 @@ const Create: NextPage = () => {
                 uri,
                 name,
                 isMutable,
-                maxSupply: unlimitedSupply ? undefined : maxSupply
+                maxSupply: unlimitedSupply ? null : maxSupply
             })
             .run()
             .catch(() => {


### PR DESCRIPTION
Closes #68 

A prior change had removed the explicit typing of the NFT creation method parameter as `CreateNftInput`. As a result, the logic to set the `maxSupply` field as `undefined` in the event that the unlimited supply checkbox was marked lost its protection against being stripped out of the RPC request. This PR changes the value from being set as `undefined` to `null` which corrects the issue and allows an unlimited supply to be set once again.